### PR TITLE
fix: fix search bar cursor not blinking when focused

### DIFF
--- a/ui/list/list.go
+++ b/ui/list/list.go
@@ -150,7 +150,6 @@ func (m *Model) Resize(width, height int) {
 func (m *Model) Reset() {
 	m.filteredTable.Reset()
 	m.filterState = unfiltered
-	m.searchBar.Reset()
 	m.currentHeading = ""
 	m.cursorToBeginning()
 	m.visibleRows()
@@ -192,10 +191,11 @@ func (m *Model) searchMode() bool {
 	return m.search && m.searchBar.Focused()
 }
 
-func (m *Model) startSearch() {
+func (m *Model) startSearch() tea.Cmd {
 	m.search = true
 	m.filterState = filtering
 	m.searchBar.Focus()
+	return textinput.Blink
 }
 
 func (m *Model) cursorToBeginning() {

--- a/ui/list/list_test.go
+++ b/ui/list/list_test.go
@@ -67,7 +67,7 @@ func TestReset(t *testing.T) {
 	tm.Reset()
 
 	assertEqual(t, tm.filteredTable.Render(), "")
-	assertEqual(t, tm.searchBar.Value(), "")
+	assertEqual(t, tm.searchBar.Value(), "searching...")
 	assertEqual(t, tm.filterState, unfiltered)
 	assertEqual(t, tm.cursor, 0)
 	assertEqual(t, tm.maxRows, tm.table.LineCount)

--- a/ui/list/update.go
+++ b/ui/list/update.go
@@ -76,11 +76,11 @@ func (m *Model) handleNormal(msg tea.Msg) tea.Cmd {
 			return tea.Quit
 
 		case key.Matches(msg, m.keys.Search):
-			m.startSearch()
+			return m.startSearch()
 
 		case key.Matches(msg, m.keys.ClearSearch):
-			m.Reset()
-			m.startSearch()
+			m.searchBar.Reset()
+			return m.startSearch()
 
 		case key.Matches(msg, m.keys.Up):
 			m.cursor--
@@ -183,8 +183,8 @@ func (m *Model) handleSearch(msg tea.Msg) tea.Cmd {
 			return tea.Quit
 
 		case key.Matches(msg, m.keys.ClearSearch):
-			m.Reset()
-			m.startSearch()
+			m.searchBar.Reset()
+			return m.startSearch()
 
 		case key.Matches(msg, m.keys.Normal):
 			m.search = false
@@ -195,19 +195,19 @@ func (m *Model) handleSearch(msg tea.Msg) tea.Cmd {
 			}
 			return nil
 		}
-
-		// filter with search input
-		m.searchBar, cmd = m.searchBar.Update(msg)
-		cmds = append(cmds, cmd)
-
-		prefix := "h:"
-		if strings.HasPrefix(m.searchBar.Value(), prefix) {
-			matchHeadings(m, prefix)
-		} else {
-			matchRows(m)
-		}
-		m.cursorToBeginning()
 	}
+
+	// filter with search input
+	m.searchBar, cmd = m.searchBar.Update(msg)
+	cmds = append(cmds, cmd)
+
+	prefix := "h:"
+	if strings.HasPrefix(m.searchBar.Value(), prefix) {
+		matchHeadings(m, prefix)
+	} else {
+		matchRows(m)
+	}
+	m.cursorToBeginning()
 
 	// reset if search input is empty regardless of filterState
 	if m.searchBar.Value() == "" {


### PR DESCRIPTION
Closes #14.

`textinput`'s cursor was not blinking as:
- Blinking was not properly initialized
- The `Update` function call of `handleSearch` was placed inside the `KeyMsg` switch-case statement, which meant the cursor would only blink on every key press.
- `m.Reset()` was being infinitely called when the search bar was empty (oops)